### PR TITLE
Add month navigation and filter budgets by month

### DIFF
--- a/api/service.py
+++ b/api/service.py
@@ -1,4 +1,6 @@
 # MARK: Imports
+from datetime import datetime
+
 from api.datasource.plaid_source import Plaid
 from api.datastore.base import DataStore
 from api.datastore.model import (
@@ -46,6 +48,9 @@ class Service:
     def get_all_budgets(self):
         budgets = self.store.retrieve_budgets()
         return budgets
+
+    def filter_budgets(self, start: datetime, end: datetime):
+        return self.store.filter_budgets(start, end)
 
     def get_budget(self, id: int):
         budget = self.store.select_budget(id)

--- a/apps/web/templates/index.html
+++ b/apps/web/templates/index.html
@@ -11,22 +11,15 @@
 
 <body>
   <main class="dashboard">
-    <header class="dashboard__header">
-      <div class="logo-circle"><img class="logo" src="/static/images/logo.png" alt="Logo" class="logo-circle__image"></div>
-      <h1 class="dashboard-header__month">
-                  <svg class="icon icon--medium" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M15 18l-6-6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-            </svg>
-      December
-                  <svg class="icon icon--medium" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-            </svg>
-      </h1>
-    </header>
+    {% include "partials/month_header.html" %}
+    <form id="month-state">
+      <input type="hidden" name="year" value="{{ year }}">
+      <input type="hidden" name="month" value="{{ month }}">
+    </form>
     <section class="dashboard__body">
-      <aside class="budget-list" id="budget-lines-container" hx-get="/budgets" hx-trigger="load"
-        hx-target="#budget-lines-container" hx-swap="innerHTML"
+      <aside class="budget-list" id="budget-lines-container"
         hx-on="click: const form = document.querySelector('#budget-summary-create'); const button = document.querySelector('.budget-list-create');  if ( form.contains(event.target) || event.target.closest('.budget-list-create') ) return;  form.classList.remove('is-active'); button.classList.add('is-active'); ">
+        {% include "partials/budget_lines.html" %}
       </aside>
       <!-- <section class="detail-panel">
           <div class="summary-card" id="summary-card" hx-get="/summary" hx-trigger="load, every 15s" hx-target="#summary-card" hx-swap="innerHTML">

--- a/apps/web/templates/partials/budget/index.html
+++ b/apps/web/templates/partials/budget/index.html
@@ -1,6 +1,7 @@
 <div class="budget-list__items">
     <button class="pill pill--xsmall budget-back-button"
             hx-get="/budgets"
+            hx-include="#month-state"
             hx-target="#budget-lines-container"
             hx-swap="innerHTML">
         <span class="pill__content">
@@ -65,6 +66,7 @@
          id="budget-item-details-container"></div>
     <button class="pill pill--flex pill--danger"
             hx-delete="/budgets/{{ id }}"
+            hx-include="#month-state"
             hx-target="#budget-lines-container"
             hx-confirm="This will permanently delete this budget and its associations. This action cannot be undone. Are you sure?">
         <span class="pill__content">Delete</span>

--- a/apps/web/templates/partials/month_header.html
+++ b/apps/web/templates/partials/month_header.html
@@ -1,0 +1,33 @@
+<header class="dashboard__header" id="month-header">
+  <div class="logo-circle"><img class="logo" src="/static/images/logo.png" alt="Logo" class="logo-circle__image"></div>
+  <h1 class="dashboard-header__month">
+    <button class="icon-button"
+            type="button"
+            hx-get="/months"
+            hx-target="#month-header"
+            hx-swap="outerHTML"
+            hx-vals='{"year": {{ year }}, "month": {{ month }}, "direction": "prev"}'>
+      <svg class="icon icon--medium" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M15 18l-6-6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </button>
+    {% if show_year %}{{ year }} {% endif %}{{ month_name }}
+    <button class="icon-button"
+            type="button"
+            hx-get="/months"
+            hx-target="#month-header"
+            hx-swap="outerHTML"
+            hx-vals='{"year": {{ year }}, "month": {{ month }}, "direction": "next"}'>
+      <svg class="icon icon--medium" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </button>
+  </h1>
+</header>
+<form id="month-state" hx-swap-oob="true">
+  <input type="hidden" name="year" value="{{ year }}">
+  <input type="hidden" name="month" value="{{ month }}">
+</form>
+<div id="budget-lines-container" hx-swap-oob="innerHTML">
+  {% include "partials/budget_lines.html" %}
+</div>


### PR DESCRIPTION
## Summary
- add month navigation controls that update the header and current month state
- filter budget listings by the selected month on initial load and navigation
- keep budget list updates in sync with the selected month and allow restoring filtered lists after budget actions

## Testing
- python -m pytest tests/db/test_sqlite3.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69548ea5115883229caf2c4f03bb8a20)