### PR TITLE
Use query params for month navigation

### DIFF
--- a/api/service.py
+++ b/api/service.py
@@ -1,4 +1,6 @@
 # MARK: Imports
+from datetime import datetime
+
 from api.datasource.plaid_source import Plaid
 from api.datastore.base import DataStore
 from api.datastore.model import (
@@ -46,6 +48,9 @@ class Service:
     def get_all_budgets(self):
         budgets = self.store.retrieve_budgets()
         return budgets
+
+    def filter_budgets(self, start: datetime, end: datetime):
+        return self.store.filter_budgets(start, end)
 
     def get_budget(self, id: int):
         budget = self.store.select_budget(id)

--- a/apps/web/templates/index.html
+++ b/apps/web/templates/index.html
@@ -11,22 +11,11 @@
 
 <body>
   <main class="dashboard">
-    <header class="dashboard__header">
-      <div class="logo-circle"><img class="logo" src="/static/images/logo.png" alt="Logo" class="logo-circle__image"></div>
-      <h1 class="dashboard-header__month">
-                  <svg class="icon icon--medium" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M15 18l-6-6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-            </svg>
-      December
-                  <svg class="icon icon--medium" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-            </svg>
-      </h1>
-    </header>
+    {% include "partials/month_header.html" %}
     <section class="dashboard__body">
-      <aside class="budget-list" id="budget-lines-container" hx-get="/budgets" hx-trigger="load"
-        hx-target="#budget-lines-container" hx-swap="innerHTML"
+      <aside class="budget-list" id="budget-lines-container"
         hx-on="click: const form = document.querySelector('#budget-summary-create'); const button = document.querySelector('.budget-list-create');  if ( form.contains(event.target) || event.target.closest('.budget-list-create') ) return;  form.classList.remove('is-active'); button.classList.add('is-active'); ">
+        {% include "partials/budget_lines.html" %}
       </aside>
       <!-- <section class="detail-panel">
           <div class="summary-card" id="summary-card" hx-get="/summary" hx-trigger="load, every 15s" hx-target="#summary-card" hx-swap="innerHTML">

--- a/apps/web/templates/partials/budget/index.html
+++ b/apps/web/templates/partials/budget/index.html
@@ -1,6 +1,6 @@
 <div class="budget-list__items">
     <button class="pill pill--xsmall budget-back-button"
-            hx-get="/budgets"
+            hx-get="/budgets?year={{ year }}&month={{ month }}"
             hx-target="#budget-lines-container"
             hx-swap="innerHTML">
         <span class="pill__content">
@@ -64,7 +64,7 @@
     <div class="budget-item-details-container"
          id="budget-item-details-container"></div>
     <button class="pill pill--flex pill--danger"
-            hx-delete="/budgets/{{ id }}"
+            hx-delete="/budgets/{{ id }}?year={{ year }}&month={{ month }}"
             hx-target="#budget-lines-container"
             hx-confirm="This will permanently delete this budget and its associations. This action cannot be undone. Are you sure?">
         <span class="pill__content">Delete</span>

--- a/apps/web/templates/partials/budget_lines.html
+++ b/apps/web/templates/partials/budget_lines.html
@@ -12,7 +12,7 @@
 </header>
 <form id="budget-summary-create"
       class="budget-summary"
-      hx-post="/budgets"
+      hx-post="/budgets?year={{ year }}&month={{ month }}"
       hx-target="#budget-lines-container"
       hx-swap="innerHTML">
   <!-- Name -->
@@ -54,7 +54,7 @@
       {% set zone = "progress__bar--warning" %}
     {% endif %}
     <li class="budget-item budget-item--card"
-        hx-get="/budgets/{{ item.id }}"
+        hx-get="/budgets/{{ item.id }}?year={{ year }}&month={{ month }}"
         hx-target="#budget-lines-container"
         hx-swap="innerHTML">
       <div class="budget-item__label">{{ item.name }}</div>

--- a/apps/web/templates/partials/month_header.html
+++ b/apps/web/templates/partials/month_header.html
@@ -1,0 +1,29 @@
+<header class="dashboard__header" id="month-header">
+  <div class="logo-circle"><img class="logo" src="/static/images/logo.png" alt="Logo" class="logo-circle__image"></div>
+  <h1 class="dashboard-header__month">
+    <button class="icon-button"
+            type="button"
+            hx-get="/?year={{ year }}&month={{ month }}&direction=prev"
+            hx-target="#month-header"
+            hx-swap="outerHTML"
+            hx-push-url="true">
+      <svg class="icon icon--medium" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M15 18l-6-6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </button>
+    {% if show_year %}{{ year }} {% endif %}{{ month_name }}
+    <button class="icon-button"
+            type="button"
+            hx-get="/?year={{ year }}&month={{ month }}&direction=next"
+            hx-target="#month-header"
+            hx-swap="outerHTML"
+            hx-push-url="true">
+      <svg class="icon icon--medium" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </button>
+  </h1>
+</header>
+<div id="budget-lines-container" hx-swap-oob="innerHTML">
+  {% include "partials/budget_lines.html" %}
+</div>


### PR DESCRIPTION
## Summary
- handle month navigation via the root route using query parameters and HTMX-friendly partial responses
- propagate the selected month/year via query strings for budget list, detail, and delete interactions instead of hidden form state
- filter budget listings after create/delete operations using the month context from query parameters

## Testing
- python -m pytest tests/db/test_sqlite3.py -p no:cov -c /dev/null

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69548ea5115883229caf2c4f03bb8a20)