### PR TITLE
Add budget overview totals, CSV import, and context menu bounds

### DIFF
--- a/apps/web/main.py
+++ b/apps/web/main.py
@@ -1,12 +1,24 @@
 # MARK: Imports
+import csv
 import os
+from io import StringIO
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import Annotated
 
 import uvicorn
-from fastapi import APIRouter, Depends, FastAPI, Form, HTTPException, Query, Request
+from fastapi import (
+    APIRouter,
+    Depends,
+    FastAPI,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    Request,
+    UploadFile,
+)
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -102,6 +114,26 @@ def _explorer_response(
     )
 
 
+def _budget_lines_response(
+    request: Request,
+    service: Service,
+    month: int,
+    year: int | None,
+) -> HTMLResponse:
+    mth_ctx = _month_context(month, year)
+    overview = service.get_budget_overview(mth_ctx["current_month"], mth_ctx["year"])
+    return templates.TemplateResponse(
+        "partials/budget_lines.html",
+        {
+            "request": request,
+            "budgets": service.get_all_budgets(
+                mth_ctx["current_month"], mth_ctx["year"]
+            ),
+            "overview": overview,
+            **mth_ctx,
+        },
+    )
+
 # MARK: Root Routes
 
 
@@ -195,16 +227,7 @@ def budget_lines(
     month: int,
     year: int | None = Query(None),
 ) -> HTMLResponse:
-    return templates.TemplateResponse(
-        "partials/budget_lines.html",
-        {
-            "request": request,
-            "budgets": service.get_all_budgets(
-                month, datetime.now().year if not year else year
-            ),
-            **_month_context(month, year),
-        },
-    )
+    return _budget_lines_response(request, service, month, year)
 
 
 @budget_router.post("", response_class=HTMLResponse)
@@ -218,16 +241,7 @@ def budget_create(
 ) -> HTMLResponse:
     service.create_budget(name, allocated if allocated is not None else 0.0)
 
-    return templates.TemplateResponse(
-        "partials/budget_lines.html",
-        {
-            "request": request,
-            "budgets": service.get_all_budgets(
-                month, datetime.now().year if not year else year
-            ),
-            **_month_context(month, year),
-        },
-    )
+    return _budget_lines_response(request, service, month, year)
 
 
 @budget_router.post("/copy", response_class=HTMLResponse)
@@ -245,16 +259,7 @@ def budget_copy(
         year,
     )
 
-    return templates.TemplateResponse(
-        "partials/budget_lines.html",
-        {
-            "request": request,
-            "budgets": service.get_all_budgets(
-                month, datetime.now().year if not year else year
-            ),
-            **mth_ctx,
-        },
-    )
+    return _budget_lines_response(request, service, month, year)
 
 
 @budget_router.get("/{id}", response_class=HTMLResponse)
@@ -321,16 +326,7 @@ def budget_delete(
 ) -> HTMLResponse:
     service.delete_budget(id)
 
-    return templates.TemplateResponse(
-        "partials/budget_lines.html",
-        {
-            "request": request,
-            "budgets": service.get_all_budgets(
-                month, datetime.now().year if not year else year
-            ),
-            **_month_context(month, year),
-        },
-    )
+    return _budget_lines_response(request, service, month, year)
 
 
 @budget_router.get("/{id}/edit", response_class=HTMLResponse)
@@ -584,6 +580,84 @@ def sync_transactions(
     service: Annotated[Service, Depends(get_service)],
 ) -> HTMLResponse:
     service.sync_all_transactions()
+    return _explorer_response(request, service)
+
+
+@transactions_router.post("/import", response_class=HTMLResponse)
+async def import_transactions(
+    request: Request,
+    service: Annotated[Service, Depends(get_service)],
+    file: UploadFile = File(...),
+) -> HTMLResponse:
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="CSV file is required.")
+
+    content = (await file.read()).decode("utf-8-sig")
+    reader = csv.DictReader(StringIO(content))
+    if not reader.fieldnames:
+        raise HTTPException(status_code=400, detail="CSV headers are missing.")
+
+    normalized_headers = {header.strip().lower(): header for header in reader.fieldnames}
+    expected = {
+        "date (yyyy-mm-dd)": "Date (YYYY-MM-DD)",
+        "description": "Description",
+        "amount": "Amount",
+        "account name": "Account Name",
+        "budget (can be empty)": "Budget (Can be Empty)",
+    }
+    missing = [
+        expected[key]
+        for key in expected
+        if key not in normalized_headers
+    ]
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Missing required columns: {', '.join(missing)}",
+        )
+
+    rows: list[dict[str, object]] = []
+    for row in reader:
+        date_raw = row.get(normalized_headers["date (yyyy-mm-dd)"], "").strip()
+        description = row.get(normalized_headers["description"], "").strip()
+        amount_raw = row.get(normalized_headers["amount"], "").strip()
+        account_name = row.get(normalized_headers["account name"], "").strip()
+        budget_name = row.get(normalized_headers["budget (can be empty)"], "").strip()
+
+        if not date_raw or not description or not amount_raw or not account_name:
+            continue
+
+        try:
+            occurred_at = datetime.fromisoformat(date_raw)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid date format: {date_raw}",
+            ) from exc
+
+        sanitized_amount = amount_raw.replace("$", "").replace(",", "")
+        try:
+            amount = float(sanitized_amount)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid amount: {amount_raw}",
+            ) from exc
+
+        rows.append(
+            {
+                "occurred_at": occurred_at,
+                "description": description,
+                "amount": amount,
+                "account_name": account_name,
+                "budget_name": budget_name,
+            }
+        )
+
+    if not rows:
+        raise HTTPException(status_code=400, detail="No valid rows to import.")
+
+    service.import_transactions_from_csv(rows)
     return _explorer_response(request, service)
 
 

--- a/apps/web/static/css/styles.css
+++ b/apps/web/static/css/styles.css
@@ -191,6 +191,54 @@ textarea[readonly] {
   gap: 16px;
 }
 
+.budget-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: calc(var(--radius) + 4px);
+  background: linear-gradient(135deg,
+      color-mix(in srgb, var(--color-primary) 12%, transparent),
+      color-mix(in srgb, var(--color-bg-surface) 92%, transparent));
+  border: 1px solid color-mix(in srgb, var(--color-text-primary) 10%, transparent);
+}
+
+.budget-overview__card {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.budget-overview__text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.budget-overview__label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.budget-overview__value {
+  font-size: 22px;
+  margin: 0;
+  color: var(--color-text-primary);
+}
+
+.budget-overview__bar {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.budget-overview__meta {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
 .section-title {
   font-size: 16px;
   text-transform: uppercase;
@@ -234,6 +282,22 @@ textarea[readonly] {
   display: flex;
   gap: 24px;
   align-items: center;
+}
+
+.explorer-import {
+  display: flex;
+}
+
+.explorer-import .pill {
+  position: relative;
+}
+
+.explorer-import__input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
 }
 
 .budget-tab-create-row {

--- a/apps/web/static/js/ui.js
+++ b/apps/web/static/js/ui.js
@@ -44,8 +44,9 @@ function openTxnContextMenu(event, rowEl) {
     menu.dataset.txnBudgeted = rowEl.dataset.txnBudgeted;
     menu.dataset.txnNote = rowEl.dataset.txnNote || '';
 
-    menu.style.top = event.clientY + 'px';
-    menu.style.left = event.clientX + 'px';
+    const rowRect = rowEl.getBoundingClientRect();
+    const clickX = Number.isFinite(event.clientX) ? event.clientX : rowRect.left;
+    const clickY = Number.isFinite(event.clientY) ? event.clientY : rowRect.top;
 
     const txnDate = new Date(rowEl.dataset.txnOccurredAt);
     const txnMonth = txnDate.getMonth() + 1;
@@ -75,6 +76,31 @@ function openTxnContextMenu(event, rowEl) {
     }
 
     menu.style.display = 'block';
+    menu.style.visibility = 'hidden';
+    menu.style.top = clickY + 'px';
+    menu.style.left = clickX + 'px';
+
+    const padding = 12;
+    const rect = menu.getBoundingClientRect();
+    let left = clickX;
+    let top = clickY;
+
+    if (rect.right > window.innerWidth - padding) {
+        left = Math.max(padding, window.innerWidth - rect.width - padding);
+    }
+    if (rect.bottom > window.innerHeight - padding) {
+        top = Math.max(padding, window.innerHeight - rect.height - padding);
+    }
+    if (left < padding) {
+        left = padding;
+    }
+    if (top < padding) {
+        top = padding;
+    }
+
+    menu.style.left = left + 'px';
+    menu.style.top = top + 'px';
+    menu.style.visibility = 'visible';
     menu.classList.add('is-visible');
     htmx.trigger(document.body, 'txn-menu-open');
 }

--- a/apps/web/templates/partials/budget_lines.html
+++ b/apps/web/templates/partials/budget_lines.html
@@ -49,6 +49,36 @@
         </div>
     {% endif %}
 </header>
+{% if overview %}
+    {% if overview.total_allocated and overview.total_allocated > 0 %}
+        {% set total_pct = (overview.total_spent / overview.total_allocated) * 100 %}
+    {% else %}
+        {% set total_pct = 0 %}
+    {% endif %}
+    {% set total_pct = total_pct | round(0) %}
+    <section class="budget-overview">
+        <div class="budget-overview__card">
+            <div class="budget-overview__text">
+                <p class="budget-overview__label">Total spent</p>
+                <h4 class="budget-overview__value">${{ '%.0f' % (overview.total_spent / 100) }}</h4>
+            </div>
+            <div class="budget-overview__text">
+                <p class="budget-overview__label">Total allocated</p>
+                <h4 class="budget-overview__value">${{ '%.0f' % (overview.total_allocated / 100) }}</h4>
+            </div>
+        </div>
+        <div class="budget-overview__bar">
+            <div class="progress"
+                 aria-valuemin="0"
+                 aria-valuemax="100"
+                 aria-valuenow="{{ total_pct|round(0) }}">
+                <div class="progress__bar"
+                     style="width: {{ [total_pct,100]| min | round(0) }}%"></div>
+            </div>
+            <span class="budget-overview__meta">{{ total_pct|round(0) }}% of allocation spent</span>
+        </div>
+    </section>
+{% endif %}
 {% if not readonly %}
     <form id="budget-summary-create"
           class="budget-summary"

--- a/apps/web/templates/partials/explorer/index.html
+++ b/apps/web/templates/partials/explorer/index.html
@@ -52,6 +52,26 @@
                 <span>Sync</span>
             </span>
         </button>
+        <form class="explorer-import"
+              hx-post="/transactions/import"
+              hx-encoding="multipart/form-data"
+              hx-target="#explorer-history"
+              hx-swap="innerHTML">
+            <label class="pill pill--xsmall pill--secondary">
+                <span class="pill__content">
+                    <svg class="icon icon--spacing" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 5v14M5 12h14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                    </svg>
+                    Import CSV
+                </span>
+                <input class="explorer-import__input"
+                       type="file"
+                       name="file"
+                       accept=".csv,text/csv"
+                       hx-on="change: this.form.requestSubmit();"
+                       required />
+            </label>
+        </form>
         <button class="pill pill--xsmall pill--secondary"
                 hx-get="/link"
                 hx-target="this"


### PR DESCRIPTION
### Motivation

- Provide a single, modern overview showing total allocated vs total spent for the selected month to help users understand overall budget health.  
- Allow bulk import of transactions from CSV to speed up onboarding and data migration.  
- Prevent the transaction context menu from rendering off-screen on phones and small windows to improve UX.  
- Keep UI consistent and minimally invasive: an import button in the Explorer and a sleek overview card in the Budget panel.

### Description

- Added `Service.get_budget_overview` to compute `total_allocated` and `total_spent` for a month and wired it into a new `_budget_lines_response` helper used by budget list endpoints.  
- Implemented CSV import handling: a new POST endpoint `POST /transactions/import` parses CSV rows with the expected columns `Date (YYYY-MM-DD), Description, Amount, Account Name, Budget (Can be Empty)` and calls `Service.import_transactions_from_csv` to insert transactions and (if possible) assign them to budgets.  
- Added service helpers to ensure/import accounts (`_ensure_import_account`) and to insert transactions and assign budgets (`import_transactions_from_csv`).  
- Added Explorer UI for importing (`Import CSV` button + hidden file input), new overview card in `partials/budget_lines.html`, styles in `apps/web/static/css/styles.css`, and JavaScript changes in `apps/web/static/js/ui.js` to clamp the transaction context menu within the viewport (mobile and desktop).  

### Testing

- Attempted to start the web server (`apps/web/main.py`) with `PYTHONPATH` and `BUTTY_DB_PATH` set; application startup failed due to missing environment variable `PLAID_CLIENT` (startup error from the Plaid client initialization), so full runtime end-to-end verification could not complete.  
- Tried to run an automated Playwright screenshot of the running site, but the browser run failed (Playwright/Chromium launch/crash) after the server could not be fully exercised.  
- No unit tests or automated test-suite runs were executed as part of this change.  
- The code changes were committed and are ready for further CI/run-time verification once `PLAID_CLIENT` (and other runtime env) are provided and Playwright environment issues are resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69632c200b38832292f91469305f78c9)