### PR TITLE
Include account info in Apple transactions sync payload

### DIFF
--- a/apps/web/main.py
+++ b/apps/web/main.py
@@ -24,7 +24,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from core.datastore.db import Sqlite3
-from core.model import AppleTransaction
+from core.model import AppleAccountTransactions
 from core.service import Service
 from core.utils import cents_to_dollars, derive_month_context
 
@@ -677,7 +677,8 @@ async def import_transactions(
 
 @transactions_router.post("/sync/apple", response_class=HTMLResponse)
 def sync_transactions_apple_webhook(
-    service: Annotated[Service, Depends(get_service)], payload: list[AppleTransaction]
+    service: Annotated[Service, Depends(get_service)],
+    payload: list[AppleAccountTransactions],
 ):
     service.sync_apple_transactions(payload)
 

--- a/core/model.py
+++ b/core/model.py
@@ -5,6 +5,14 @@ from pydantic import BaseModel
 from core.datastore.model import TransactionDirection
 
 
+class AppleAccountInfo(BaseModel):
+    id: str
+    display_name: str
+    available_balance: float | None = None
+    institution_name: str | None = None
+    card_last4: str | None = None
+
+
 class AppleTransaction(BaseModel):
     id: str
     account_id: str
@@ -12,3 +20,8 @@ class AppleTransaction(BaseModel):
     amount: float
     direction: TransactionDirection
     date: datetime
+
+
+class AppleAccountTransactions(BaseModel):
+    account: AppleAccountInfo
+    transactions: list[AppleTransaction]


### PR DESCRIPTION
### Motivation
- Provide account metadata (id, display name, available balance, institution, last4) alongside FinanceKit transactions so the backend can persist account details and associate transactions correctly.
- Group transactions by account in the iOS sync payload to maintain account context for each transaction batch.
- Update the core API models and service to accept the new grouped payload shape coming from the iOS app.

### Description
- iOS: added `ExportAccountInfo` and `ExportAccountTransactions` and replaced the flat export with `mapAccountTransactions` in `apps/ios/FinanceKitSync/FinanceKitSync/ContentView.swift` to include account metadata and group transactions by account.
- Core API: added `AppleAccountInfo` and `AppleAccountTransactions` models to `core/model.py` so the web API and service can validate the grouped payload.
- Service: updated `sync_apple_transactions` in `core/service.py` to accept `list[AppleAccountTransactions]`, build account fingerprints from account metadata, create or find corresponding accounts with the provided balance/name/institution/last4, and insert linked transactions under that account.
- Web API: changed the Apple webhook endpoint in `apps/web/main.py` to accept `list[AppleAccountTransactions]` and forward it to `sync_apple_transactions`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696400baea348322b28a5652e0744d69)