### PR TITLE
Fix transaction context menu in search results

### DIFF
--- a/apps/web/templates/partials/explorer/search.html
+++ b/apps/web/templates/partials/explorer/search.html
@@ -1,5 +1,10 @@
 {% for transaction in transactions %}
-    <tr>
+    <tr class="explorer-row"
+        data-txn-id="{{ transaction.id }}"
+        data-txn-occurred-at="{{ transaction.occurred_at }}"
+        data-txn-budgeted="{{ 1 if transaction.budget_name else 0 }}"
+        data-txn-note="{{ transaction.note | default('') }}"
+        hx-on="contextmenu: openTxnContextMenu(event, this)">
         <td>{{ transaction.occurred_at.strftime("%b %d, %Y %I:%M %p") }}</td>
         <td class="strong">{{ transaction.name }}</td>
         <td>${{ '%.2f' % (transaction.amount / 100) }}</td>
@@ -9,5 +14,12 @@
         </td>
         <td>{{ transaction.account_name }}</td>
         <td>{{ transaction.budget_name }}</td>
+        <td class="align-center">
+            <button class="pill pill--ghost pill--xsmall"
+                    aria-label="Transaction actions"
+                    hx-on="click: openTxnContextMenu(event, this.closest('[data-txn-id]'))">
+                ⋯
+            </button>
+        </td>
     </tr>
 {% endfor %}


### PR DESCRIPTION
### Motivation
- Search result rows did not include the explorer row metadata or context-menu trigger, so the three-dot actions menu did not appear when searching transactions.
- Searched rows need to behave the same as rows in the main explorer table to allow actions like assign/remove budget and add notes.
- The issue is UI-only and rooted in the search partial template not providing the required attributes and handlers.

### Description
- Update `apps/web/templates/partials/explorer/search.html` to add `class="explorer-row"` and data attributes `data-txn-id`, `data-txn-occurred-at`, `data-txn-budgeted`, and `data-txn-note` to each searched row.
- Add `hx-on="contextmenu: openTxnContextMenu(event, this)"` to enable right-click context menu on searched rows.
- Render the actions button (ellipsis) per row with `hx-on="click: openTxnContextMenu(event, this.closest('[data-txn-id]'))"` so the three-dot menu can also be opened via the button.
- This change is template-only and does not modify backend logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69641f41e7e08322942995788291480d)