### PR TITLE
Use viewed month/year for transaction context menu budget actions

### DIFF
--- a/apps/web/static/js/ui.js
+++ b/apps/web/static/js/ui.js
@@ -85,10 +85,9 @@ function openTxnContextMenu(event, rowEl) {
     const removeItem = menu.querySelector('[data-action=remove-budget]');
     const assignItem = menu.querySelector('[data-action=assign-budget]');
 
-    // Determine current period
-    const now = new Date();
-    const currentMonth = now.getMonth() + 1; // JS months are 0-based
-    const currentYear = now.getFullYear();
+    // Determine viewed period from context menu metadata
+    const currentMonth = Number(menu.dataset.currentMonth);
+    const currentYear = Number(menu.dataset.currentYear);
 
     menu.dataset.txnId = rowEl.dataset.txnId;
     menu.dataset.txnOccurredAt = rowEl.dataset.txnOccurredAt;


### PR DESCRIPTION
### Motivation
- Fix a bug where the transaction context menu used the device clock to determine whether budget actions were available, which blocked assigning/removing budgets when viewing a different month (e.g. a Feb 1 transaction while viewing February). The decision should use the explorer's selected period.

### Description
- Update `openTxnContextMenu` in `apps/web/static/js/ui.js` to read the viewed period from `menu.dataset.currentMonth` and `menu.dataset.currentYear` instead of using `new Date()` to determine the current period, so budget assignment/remove visibility is evaluated against the viewed month/year.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69800c46acbc832293991b4b39e601eb)