### PR TITLE
Remove duplicate Plaid Items after duplicate-only link attempts

### DIFF
--- a/apps/web/main.py
+++ b/apps/web/main.py
@@ -116,6 +116,7 @@ def _activity_context(
     service: Annotated[Service, Depends(get_service)],
     month: int | None = None,
     year: int | None = None,
+    plaid_notice: dict[str, str] | None = None,
 ) -> dict:
     mth_ctx = _month_context(month, year)
     recent_transactions = service.get_all_recent_transactions(
@@ -128,6 +129,7 @@ def _activity_context(
         "transactions": transactions,
         "accounts": accounts,
         "budgets": service.get_all_budgets(mth_ctx["current_month"], mth_ctx["year"]),
+        "plaid_notice": plaid_notice,
         **mth_ctx,
     }
 
@@ -137,12 +139,13 @@ def _explorer_response(
     service: Annotated[Service, Depends(get_service)],
     month: int | None = None,
     year: int | None = None,
+    plaid_notice: dict[str, str] | None = None,
 ):
     return templates.TemplateResponse(
         "partials/explorer/index.html",
         {
             "request": request,
-            **_activity_context(service, month, year),
+            **_activity_context(service, month, year, plaid_notice),
             **_base_context(service),
         },
     )
@@ -735,9 +738,42 @@ def create_account_by_plaid(
     service: Annotated[Service, Depends(get_service)],
     public_token: str = Form(...),
 ) -> HTMLResponse:
-    service.create_accounts_by_plaid(public_token)
-    service.sync_all_transactions()
-    return _explorer_response(request, service)
+    link_result = service.create_accounts_by_plaid(public_token)
+
+    linked_new_accounts = int(link_result["linked_new_accounts"])
+    duplicate_accounts = int(link_result["duplicate_accounts"])
+    removed_duplicate_item = bool(link_result["removed_duplicate_item"])
+
+    if linked_new_accounts > 0:
+        service.sync_all_transactions()
+
+    if linked_new_accounts > 0 and duplicate_accounts > 0:
+        plaid_notice = {
+            "level": "success",
+            "message": (
+                f"Linked {linked_new_accounts} new account(s). "
+                f"Skipped {duplicate_accounts} duplicate account(s)."
+            ),
+        }
+    elif linked_new_accounts > 0:
+        plaid_notice = {
+            "level": "success",
+            "message": f"Linked {linked_new_accounts} new account(s).",
+        }
+    else:
+        plaid_notice = {
+            "level": "warning",
+            "message": (
+                "This institution is already linked. "
+                + (
+                    "No duplicate account was added and the duplicate link was removed."
+                    if removed_duplicate_item
+                    else "No duplicate account was added."
+                )
+            ),
+        }
+
+    return _explorer_response(request, service, plaid_notice=plaid_notice)
 
 
 # MARK: Router Registration

--- a/apps/web/static/css/styles.css
+++ b/apps/web/static/css/styles.css
@@ -774,6 +774,25 @@ textarea[readonly] {
   overflow: hidden;
 }
 
+.explorer-notice {
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.explorer-notice--success {
+  background: #eafaf1;
+  color: #13673f;
+  border: 1px solid #b7efcf;
+}
+
+.explorer-notice--warning {
+  background: #fff8e8;
+  color: #915f05;
+  border: 1px solid #f3d9a3;
+}
+
 .budget-list.is-collapsed,
 #explorer-history.is-collapsed {
   gap: 0;

--- a/apps/web/templates/partials/explorer/index.html
+++ b/apps/web/templates/partials/explorer/index.html
@@ -85,6 +85,11 @@
         </button>
     </div>
 </header>
+{% if plaid_notice %}
+    <div class="explorer-notice explorer-notice--{{ plaid_notice.level }}" role="status">
+        {{ plaid_notice.message }}
+    </div>
+{% endif %}
 <section id="explorer-history-section" class="explorer-section">
     <!-- Explorer Recent -->
     <aside class="explorer-recent">

--- a/core/datasource/plaid_source.py
+++ b/core/datasource/plaid_source.py
@@ -10,6 +10,7 @@ try:  # pragma: no cover - import guard exercised by tests
     from plaid.model.item_public_token_exchange_request import (
         ItemPublicTokenExchangeRequest,
     )
+    from plaid.model.item_remove_request import ItemRemoveRequest
     from plaid.model.link_token_create_request import LinkTokenCreateRequest
     from plaid.model.link_token_create_request_user import LinkTokenCreateRequestUser
     from plaid.model.products import Products
@@ -23,6 +24,7 @@ except ModuleNotFoundError:  # pragma: no cover - exercised by tests
     AccountsGetRequest = None
     CountryCode = None
     ItemPublicTokenExchangeRequest = None
+    ItemRemoveRequest = None
     LinkTokenCreateRequest = None
     LinkTokenCreateRequestUser = None
     Products = None
@@ -47,6 +49,7 @@ class Plaid:
             LinkTokenCreateRequestUser,
             Products,
             TransactionsSyncRequest,
+            ItemRemoveRequest,
         ):
             raise ImportError(
                 "Plaid SDK is required. Install the 'plaid-python' package to use this datasource."
@@ -82,6 +85,11 @@ class Plaid:
         exchange_request = ItemPublicTokenExchangeRequest(public_token=public_token)
         exchange_response = self.client.item_public_token_exchange(exchange_request)
         return exchange_response["access_token"]
+
+
+    def remove_financial_item(self, access_token: str):
+        request = ItemRemoveRequest(access_token=access_token)
+        self.client.item_remove(request)
 
     def retrieve_transactions(
         self, access_token: str, cursor: str | None = None

--- a/core/service.py
+++ b/core/service.py
@@ -449,7 +449,7 @@ class Service:
     def create_accounts_by_plaid(
         self,
         public_token: str,
-    ):
+    ) -> dict[str, int | bool]:
         access_token = self.plaid_client.add_financial_item(public_token)
         accounts = self.plaid_client.retrieve_accounts(access_token)
 
@@ -461,12 +461,14 @@ class Service:
         }
 
         new_accounts_data: list[dict] = []
+        duplicate_accounts_count = 0
 
         for account in accounts:
             fingerprint = account.fingerprint
 
             # Skip accounts that already exist (stable identity)
             if self.store.account_exists_by_fingerprint(fingerprint):
+                duplicate_accounts_count += 1
                 continue
 
             new_accounts_data.append(
@@ -480,9 +482,18 @@ class Service:
                 }
             )
 
-        # 🚫 No new accounts discovered → do NOT persist access token
+        # 🚫 No new accounts discovered → do NOT persist access token.
+        # Also remove the newly created Plaid Item to avoid ongoing costs.
         if not new_accounts_data:
-            return
+            if duplicate_accounts_count > 0:
+                self.plaid_client.remove_financial_item(access_token)
+
+            return {
+                "linked_new_accounts": 0,
+                "duplicate_accounts": duplicate_accounts_count,
+                "duplicate_item_detected": duplicate_accounts_count > 0,
+                "removed_duplicate_item": duplicate_accounts_count > 0,
+            }
 
         # ✅ At least one new account → now persist access token
         plaid_id = self.store.insert_plaid_account(access_token)
@@ -490,3 +501,10 @@ class Service:
         for data in new_accounts_data:
             data["plaid_id"] = plaid_id
             self.store.insert_account(PartialAccount(**data))
+
+        return {
+            "linked_new_accounts": len(new_accounts_data),
+            "duplicate_accounts": duplicate_accounts_count,
+            "duplicate_item_detected": False,
+            "removed_duplicate_item": False,
+        }

--- a/tests/datasource/test_plaid_source.py
+++ b/tests/datasource/test_plaid_source.py
@@ -47,6 +47,11 @@ class DummyItemPublicTokenExchangeRequest:
         self.public_token = public_token
 
 
+class DummyItemRemoveRequest:
+    def __init__(self, access_token):
+        self.access_token = access_token
+
+
 class DummyTransactionsSyncRequest:
     def __init__(self, access_token, cursor=None):
         self.access_token = access_token
@@ -89,6 +94,7 @@ class DummyPlaidApi:
         self.exchange_requests = []
         self.sync_requests = []
         self.accounts_requests = []
+        self.remove_requests = []
         self.transactions_responses = [
             {"added": ["t1"], "has_more": True, "next_cursor": "cursor-1"},
             {"added": ["t2"], "has_more": False, "next_cursor": "cursor-2"},
@@ -105,6 +111,10 @@ class DummyPlaidApi:
     def transactions_sync(self, request):
         self.sync_requests.append(request)
         return self.transactions_responses.pop(0)
+
+    def item_remove(self, request):
+        self.remove_requests.append(request)
+        return {"removed": True}
 
     def accounts_get(self, request):
         self.accounts_requests.append(request)
@@ -163,6 +173,9 @@ item_public_token_module.ItemPublicTokenExchangeRequest = (
     DummyItemPublicTokenExchangeRequest
 )
 
+item_remove_module = types.ModuleType("plaid.model.item_remove_request")
+item_remove_module.ItemRemoveRequest = DummyItemRemoveRequest
+
 sys.modules.update(
     {
         "plaid": plaid_module,
@@ -178,6 +191,7 @@ sys.modules.update(
         "plaid.model.transactions_sync_request": transactions_sync_module,
         "plaid.model.accounts_get_request": accounts_get_module,
         "plaid.model.item_public_token_exchange_request": item_public_token_module,
+        "plaid.model.item_remove_request": item_remove_module,
     }
 )
 
@@ -205,6 +219,7 @@ def patch_plaid_dependencies(monkeypatch):
         "ItemPublicTokenExchangeRequest",
         DummyItemPublicTokenExchangeRequest,
     )
+    monkeypatch.setattr(plaid_source, "ItemRemoveRequest", DummyItemRemoveRequest)
     monkeypatch.setattr(
         plaid_source, "TransactionsSyncRequest", DummyTransactionsSyncRequest
     )
@@ -269,3 +284,12 @@ def test_retrieve_accounts_builds_domain_objects(monkeypatch):
     assert fingerprints[0] == ("inst-123", "Check", "checking", None)
     assert fingerprints[1] == ("inst-123", "Savings", "savings", None)
     assert accounts[0].balance == 50.5
+
+
+def test_remove_financial_item_calls_item_remove():
+    plaid = plaid_source.Plaid()
+
+    plaid.remove_financial_item("access-789")
+
+    remove_request = plaid.client.remove_requests[0]
+    assert remove_request.access_token == "access-789"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -23,6 +23,7 @@ class FakePlaid:
     def __init__(self):
         self.link_token_called = False
         self.retrieve_transactions_calls = []
+        self.removed_access_tokens = []
 
     def create_link(self):
         self.link_token_called = True
@@ -38,6 +39,10 @@ class FakePlaid:
             PlaidAccountBase("acc1", "Checking", "finger1", "depository", 1200),
             PlaidAccountBase("acc2", "Credit", "finger2", "credit", 800),
         ]
+
+
+    def remove_financial_item(self, access_token: str):
+        self.removed_access_tokens.append(access_token)
 
     def retrieve_transactions(self, access_token: str, cursor: str | None = None):
         self.retrieve_transactions_calls.append((access_token, cursor))
@@ -488,14 +493,27 @@ def test_create_accounts_by_plaid(service):
             "finger2",
         ),
     ]
-    service.create_accounts_by_plaid("public-token")
+    duplicate_result = service.create_accounts_by_plaid("public-token")
     assert service.store.plaid_inserted_token is None
+    assert duplicate_result == {
+        "linked_new_accounts": 0,
+        "duplicate_accounts": 2,
+        "duplicate_item_detected": True,
+        "removed_duplicate_item": True,
+    }
+    assert service.plaid_client.removed_access_tokens == ["access-public-token"]
 
     # Branch with new accounts
     service.store.inserted_accounts.clear()
-    service.create_accounts_by_plaid("public-token")
+    linked_result = service.create_accounts_by_plaid("public-token")
     assert service.store.plaid_inserted_token == "access-public-token"
     assert any(acc.plaid_id == 99 for acc in service.store.inserted_accounts)
+    assert linked_result == {
+        "linked_new_accounts": 2,
+        "duplicate_accounts": 0,
+        "duplicate_item_detected": False,
+        "removed_duplicate_item": False,
+    }
 
 
 def test_import_transactions_from_csv_reuses_existing_transaction_id(service):


### PR DESCRIPTION
### Motivation
- Prevent persisting Plaid access tokens when a link attempt yields only accounts that already exist, and avoid ongoing costs from a redundant Plaid Item.
- Surface a clear UI message when a duplicate-only link was auto-removed so users understand what happened.

### Description
- Added Plaid `item/remove` support to the datasource by importing `ItemRemoveRequest` and implementing `remove_financial_item(access_token)` in `core/datasource/plaid_source.py` so the client can call `/item/remove` through the SDK.
- Updated `Service.create_accounts_by_plaid` in `core/service.py` to detect duplicate-only link attempts, call `remove_financial_item(access_token)` when appropriate, avoid persisting the access token, and return a new `removed_duplicate_item` flag in the result payload.
- Updated the `/accounts/plaid` endpoint in `apps/web/main.py` to consume the expanded payload and show a warning message indicating when a duplicate link was removed, and threaded that notice into the explorer template.
- Added styles and a transient notice area in `apps/web/templates/partials/explorer/index.html` and `apps/web/static/css/styles.css` to display success and warning messages; and extended unit tests to assert duplicate-item removal behavior in `tests/test_service.py` and `tests/datasource/test_plaid_source.py`.

### Testing
- Ran unit tests with `pytest -q -o addopts='' tests/test_service.py tests/test_web_main.py tests/datasource/test_plaid_source.py`, which completed successfully (`23 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ddcccadf883228cbc1a076e501589)