### PR TITLE
Run Plaid auto-sync every 24 hours instead of weekly Friday

### DIFF
--- a/apps/web/main.py
+++ b/apps/web/main.py
@@ -41,24 +41,21 @@ def resolve_db_path(db_path: Path | None = None) -> Path:
     return path.resolve()
 
 
-def _seconds_until_next_friday_3pm(now: datetime | None = None) -> float:
-    current = now or datetime.now()
-    target = current.replace(hour=15, minute=0, second=0, microsecond=0)
+def _seconds_until_next_daily_sync(now: datetime | None = None) -> float:
+    """Return the number of seconds before the next sync should run.
 
-    days_ahead = (4 - current.weekday()) % 7
-    if days_ahead == 0 and current >= target:
-        days_ahead = 7
-
-    target = target + timedelta(days=days_ahead)
-    return max((target - current).total_seconds(), 0)
+    Sync is executed every 24 hours.
+    """
+    _ = now
+    return timedelta(days=1).total_seconds()
 
 
-def _start_weekly_plaid_sync_thread(service: Service):
+def _start_daily_plaid_sync_thread(service: Service):
     stop_event = threading.Event()
 
     def run_sync_loop():
         while not stop_event.is_set():
-            wait_seconds = _seconds_until_next_friday_3pm()
+            wait_seconds = _seconds_until_next_daily_sync()
             interrupted = stop_event.wait(wait_seconds)
             if interrupted:
                 break
@@ -73,7 +70,7 @@ def _start_weekly_plaid_sync_thread(service: Service):
 async def startup(app: FastAPI):
     db_path = resolve_db_path(getattr(app.state, "database_path", None))
     app.state.service = Service(Sqlite3(db_path))
-    stop_event, sync_thread = _start_weekly_plaid_sync_thread(app.state.service)
+    stop_event, sync_thread = _start_daily_plaid_sync_thread(app.state.service)
     try:
         yield
     finally:

--- a/tests/test_web_main.py
+++ b/tests/test_web_main.py
@@ -1,13 +1,13 @@
 import datetime
 
-from apps.web.main import _seconds_until_next_friday_3pm
+from apps.web.main import _seconds_until_next_daily_sync
 
 
-def test_seconds_until_next_friday_3pm_before_target_same_day():
+def test_seconds_until_next_daily_sync_is_24_hours():
     now = datetime.datetime(2024, 5, 10, 14, 0)  # Friday
-    assert _seconds_until_next_friday_3pm(now) == 3600
+    assert _seconds_until_next_daily_sync(now) == 24 * 3600
 
 
-def test_seconds_until_next_friday_3pm_after_target_rolls_to_next_week():
+def test_seconds_until_next_daily_sync_is_24_hours_after_any_time():
     now = datetime.datetime(2024, 5, 10, 16, 0)  # Friday
-    assert _seconds_until_next_friday_3pm(now) == 6 * 24 * 3600 + 23 * 3600
+    assert _seconds_until_next_daily_sync(now) == 24 * 3600


### PR DESCRIPTION
### Motivation
- The background Plaid sync should run every 24 hours instead of being scheduled for Fridays at 3pm to provide daily updates.

### Description
- Replaced the Friday-targeted helper with `_seconds_until_next_daily_sync` which returns a fixed `timedelta(days=1).total_seconds()` interval.
- Renamed the worker starter to `_start_daily_plaid_sync_thread` and updated its loop to call `_seconds_until_next_daily_sync` between runs.
- Wired the app startup to use the daily sync thread instead of the weekly one by invoking `_start_daily_plaid_sync_thread` in the lifespan handler.
- Updated unit tests to import and assert ` _seconds_until_next_daily_sync` returns `24 * 3600` for the sample datetimes.

### Testing
- Attempted `pytest -q tests/test_web_main.py` initially failed due to repository `pyproject.toml` injecting coverage args not supported in this environment.
- Ran `pytest -q -o addopts='' tests/test_web_main.py` and the test suite passed: `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69915f4044248322817713a11f44e695)