### PR TITLE
Show actual balance update time in explorer balances list

### DIFF
--- a/apps/web/main.py
+++ b/apps/web/main.py
@@ -50,6 +50,35 @@ def _seconds_until_next_daily_sync(now: datetime | None = None) -> float:
     return timedelta(days=1).total_seconds()
 
 
+def _format_balance_last_updated(
+    last_updated_at: str | datetime | None, now: datetime | None = None
+) -> str:
+    if not last_updated_at:
+        return "Updated recently"
+
+    parsed = last_updated_at
+    if isinstance(last_updated_at, str):
+        try:
+            parsed = datetime.fromisoformat(last_updated_at)
+        except ValueError:
+            return "Updated recently"
+
+    if not isinstance(parsed, datetime):
+        return "Updated recently"
+
+    now = now or datetime.now(parsed.tzinfo)
+    if (
+        parsed.year == now.year
+        and parsed.month == now.month
+        and parsed.day == now.day
+        and parsed.hour == now.hour
+        and parsed.minute == now.minute
+    ):
+        return "Updated just now"
+
+    return f"Updated {parsed.strftime('%b %d, %Y %I:%M %p')}"
+
+
 def _start_daily_plaid_sync_thread(service: Service):
     stop_event = threading.Event()
 
@@ -95,6 +124,7 @@ def get_service():
 
 
 templates = Jinja2Templates(directory="apps/web/templates")
+templates.env.filters["balance_last_updated"] = _format_balance_last_updated
 app.mount("/static", StaticFiles(directory="apps/web/static"), name="static")
 
 

--- a/apps/web/templates/partials/explorer/index.html
+++ b/apps/web/templates/partials/explorer/index.html
@@ -144,7 +144,9 @@
                     {% for account in accounts %}
                         <li>
                             <p class="list__title">{{ account.name }}</p>
-                            <p class="list__meta">Updated just now</p>
+                            <p class="list__meta">
+                                {{ (account.last_updated_at if account.last_updated_at is defined else none) | balance_last_updated }}
+                            </p>
                             <span class="list__amount">${{ '%.2f' % (account.balance / 100) }}</span>
                         </li>
                     {% endfor %}

--- a/tests/test_web_main.py
+++ b/tests/test_web_main.py
@@ -1,6 +1,6 @@
 import datetime
 
-from apps.web.main import _seconds_until_next_daily_sync
+from apps.web.main import _format_balance_last_updated, _seconds_until_next_daily_sync
 
 
 def test_seconds_until_next_daily_sync_is_24_hours():
@@ -11,3 +11,19 @@ def test_seconds_until_next_daily_sync_is_24_hours():
 def test_seconds_until_next_daily_sync_is_24_hours_after_any_time():
     now = datetime.datetime(2024, 5, 10, 16, 0)  # Friday
     assert _seconds_until_next_daily_sync(now) == 24 * 3600
+
+
+def test_format_balance_last_updated_uses_just_now_within_same_minute():
+    now = datetime.datetime(2024, 5, 10, 16, 0, 45)
+    last_updated = datetime.datetime(2024, 5, 10, 16, 0, 1)
+
+    assert _format_balance_last_updated(last_updated, now) == "Updated just now"
+
+
+def test_format_balance_last_updated_uses_timestamp_for_older_updates():
+    now = datetime.datetime(2024, 5, 10, 16, 1, 0)
+
+    assert (
+        _format_balance_last_updated("2024-05-10 16:00:01", now)
+        == "Updated May 10, 2024 04:00 PM"
+    )


### PR DESCRIPTION
### Motivation
- The balances list showed a hardcoded "Updated just now" instead of reflecting the account's real `last_updated_at` timestamp, causing misleading UI copy; the intent is to show the real update time and only say "Updated just now" when the timestamp is in the same minute as now.

### Description
- Added helper ` _format_balance_last_updated` in `apps/web/main.py` to format `last_updated_at` and return `"Updated just now"` only when the timestamp and now share year/month/day/hour/minute, otherwise returning a formatted timestamp, and returning `"Updated recently"` for missing/invalid values.
- Registered the helper as a Jinja filter with `templates.env.filters["balance_last_updated"] = _format_balance_last_updated` so templates can reuse it.
- Updated the explorer balances template `apps/web/templates/partials/explorer/index.html` to use `(account.last_updated_at if account.last_updated_at is defined else none) | balance_last_updated` instead of the hardcoded copy.
- Added unit tests in `tests/test_web_main.py` for same-minute behavior and for older timestamps using ` _format_balance_last_updated`.

### Testing
- Ran `pytest -q -o addopts='' tests/test_web_main.py` and all tests passed (`4 passed`).
- Running `pytest -q tests/test_web_main.py` without overriding `addopts` failed due to the repository `pytest` config injecting coverage args not supported in this environment, so the explicit override above was used and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991649a354c8322a7c440c2e14b01ee)