### PR TITLE
Fix auto-assigning mapped Plaid categories after month copy

### DIFF
--- a/core/datastore/base.py
+++ b/core/datastore/base.py
@@ -137,6 +137,9 @@ class DataStore(ABC):
     @abstractmethod
     def select_budget_id_by_plaid_category(self, detailed: str) -> int | None: ...
 
+    @abstractmethod
+    def select_budget_ids_by_plaid_category(self, detailed: str) -> list[int]: ...
+
     # -------- Accounts --------
     @abstractmethod
     def account_exists_by_fingerprint(self, fingerprint: str) -> int | None: ...
@@ -187,3 +190,8 @@ class DataStore(ABC):
     def select_budget_id_by_plaid_category_id(
         self, plaid_category_id: int
     ) -> int | None: ...
+
+    @abstractmethod
+    def select_budget_ids_by_plaid_category_id(
+        self, plaid_category_id: int
+    ) -> list[int]: ...

--- a/core/datastore/db.py
+++ b/core/datastore/db.py
@@ -506,8 +506,12 @@ class Sqlite3(DataStore):
             return [PlaidCategoryMapping(**dict(row._mapping)) for row in rows]
 
     def select_budget_id_by_plaid_category(self, category_key: str) -> int | None:
+        budget_ids = self.select_budget_ids_by_plaid_category(category_key)
+        return budget_ids[0] if budget_ids else None
+
+    def select_budget_ids_by_plaid_category(self, category_key: str) -> list[int]:
         with self.engine.begin() as conn:
-            row = conn.execute(
+            rows = conn.execute(
                 select(self.plaid_category_mappings.c.budget_id)
                 .join(
                     self.plaid_categories,
@@ -518,23 +522,29 @@ class Sqlite3(DataStore):
                     (self.plaid_categories.c.detailed == category_key)
                     | (self.plaid_categories.c.primary == category_key)
                 )
-                .limit(1)
-            ).first()
-            return row.budget_id if row else None
+                .order_by(self.plaid_category_mappings.c.budget_id.desc())
+            ).fetchall()
+            return [row.budget_id for row in rows]
 
     def select_budget_id_by_plaid_category_id(
         self, plaid_category_id: int
     ) -> int | None:
+        budget_ids = self.select_budget_ids_by_plaid_category_id(plaid_category_id)
+        return budget_ids[0] if budget_ids else None
+
+    def select_budget_ids_by_plaid_category_id(
+        self, plaid_category_id: int
+    ) -> list[int]:
         with self.engine.begin() as conn:
-            row = conn.execute(
+            rows = conn.execute(
                 select(self.plaid_category_mappings.c.budget_id)
                 .where(
                     self.plaid_category_mappings.c.plaid_category_id
                     == plaid_category_id
                 )
-                .limit(1)
-            ).first()
-            return row.budget_id if row else None
+                .order_by(self.plaid_category_mappings.c.budget_id.desc())
+            ).fetchall()
+            return [row.budget_id for row in rows]
 
     # MARK: - Accounts
     def account_exists_by_fingerprint(self, fingerprint: str) -> int | None:

--- a/core/service.py
+++ b/core/service.py
@@ -427,36 +427,47 @@ class Service:
                         transaction_id, category_id
                     )
 
-                
+
+                assigned_to_mapped_budget = False
                 if detailed:
-                    budget_id = self.store.select_budget_id_by_plaid_category(detailed)
-                    if (
-                        budget_id
-                        and self.__occurs_in_month(date, month, year)
-                        and direction == TransactionDirection.OUT
-                        and self.__budget_in_scope(budget_id, month, year)
-                        and not self.store.ignored_budget_transaction_exists(
-                            budget_id, transaction_id
-                        )
-                    ):
-                        self.store.insert_budget_transaction(budget_id, transaction_id)
-                        touched_budgets.add(budget_id)
+                    budget_ids = self.store.select_budget_ids_by_plaid_category(detailed)
+                    for budget_id in budget_ids:
+                        if (
+                            self.__occurs_in_month(date, month, year)
+                            and direction == TransactionDirection.OUT
+                            and self.__budget_in_scope(budget_id, month, year)
+                            and not self.store.ignored_budget_transaction_exists(
+                                budget_id, transaction_id
+                            )
+                        ):
+                            self.store.insert_budget_transaction(
+                                budget_id, transaction_id
+                            )
+                            touched_budgets.add(budget_id)
+                            assigned_to_mapped_budget = True
+                            break
+                    if assigned_to_mapped_budget:
                         continue
 
                 # Fallback: try primary-level match if detailed not mapped
                 if primary:
-                    budget_id = self.store.select_budget_id_by_plaid_category(primary)
-                    if (
-                        budget_id
-                        and self.__occurs_in_month(date, month, year)
-                        and direction == TransactionDirection.OUT
-                        and self.__budget_in_scope(budget_id, month, year)
-                        and not self.store.ignored_budget_transaction_exists(
-                            budget_id, transaction_id
-                        )
-                    ):
-                        self.store.insert_budget_transaction(budget_id, transaction_id)
-                        touched_budgets.add(budget_id)
+                    budget_ids = self.store.select_budget_ids_by_plaid_category(primary)
+                    for budget_id in budget_ids:
+                        if (
+                            self.__occurs_in_month(date, month, year)
+                            and direction == TransactionDirection.OUT
+                            and self.__budget_in_scope(budget_id, month, year)
+                            and not self.store.ignored_budget_transaction_exists(
+                                budget_id, transaction_id
+                            )
+                        ):
+                            self.store.insert_budget_transaction(
+                                budget_id, transaction_id
+                            )
+                            touched_budgets.add(budget_id)
+                            assigned_to_mapped_budget = True
+                            break
+                    if assigned_to_mapped_budget:
                         continue
 
                 tag_budget_id = self.__match_budget_by_transaction_tags(
@@ -491,27 +502,25 @@ class Service:
             if txn_id is None:
                 continue
 
-            budget_id = self.store.select_budget_id_by_plaid_category_id(
+            occurred_at = getattr(txn, "occurred_at", None)
+            budget_ids = self.store.select_budget_ids_by_plaid_category_id(
                 plaid_category_id
             )
-            if not budget_id:
-                continue
-
-            already_mapped = self.store.select_budget_id_for_transaction(txn_id)
-            if already_mapped == budget_id:
-                continue
-
-            occurred_at = getattr(txn, "occurred_at", None)
-            if (
-                self.__occurs_in_month(occurred_at, month, year)
-                and txn.direction == TransactionDirection.OUT
-                and self.__budget_in_scope(budget_id, month, year)
-                and not self.store.ignored_budget_transaction_exists(
-                    budget_id, txn_id
-                )
-            ):
-                self.store.insert_budget_transaction(budget_id, txn_id)
-                touched_budgets.add(budget_id)
+            for budget_id in budget_ids:
+                already_mapped = self.store.select_budget_id_for_transaction(txn_id)
+                if already_mapped == budget_id:
+                    continue
+                if (
+                    self.__occurs_in_month(occurred_at, month, year)
+                    and txn.direction == TransactionDirection.OUT
+                    and self.__budget_in_scope(budget_id, month, year)
+                    and not self.store.ignored_budget_transaction_exists(
+                        budget_id, txn_id
+                    )
+                ):
+                    self.store.insert_budget_transaction(budget_id, txn_id)
+                    touched_budgets.add(budget_id)
+                    break
 
         for budget_id in touched_budgets:
             self.refresh_budget_spent(budget_id)

--- a/tests/test_db_plaid_categories.py
+++ b/tests/test_db_plaid_categories.py
@@ -28,3 +28,19 @@ def test_plaid_category_crud(tmp_path: Path):
     assert db.select_budget_id_by_plaid_category("FOOD_RESTAURANT") == 1
     assert db.select_budget_id_by_plaid_category("FOOD") == 1
     assert db.select_budget_id_by_plaid_category_id(cat_id1) == 1
+
+
+def test_plaid_category_lookup_prefers_latest_budget_month(tmp_path: Path):
+    db = Sqlite3(tmp_path / "test.sqlite")
+
+    db.insert_budget("Food - Feb", 100, override_create_date=datetime.datetime(2024, 2, 1))
+    db.insert_budget("Food - Mar", 100, override_create_date=datetime.datetime(2024, 3, 1))
+
+    cat_id = db.upsert_plaid_category("FOOD", "FOOD_RESTAURANT")
+    db.replace_budget_plaid_category_mappings(1, [cat_id])
+    db.replace_budget_plaid_category_mappings(2, [cat_id])
+
+    assert db.select_budget_ids_by_plaid_category("FOOD_RESTAURANT") == [2, 1]
+    assert db.select_budget_id_by_plaid_category("FOOD_RESTAURANT") == 2
+    assert db.select_budget_ids_by_plaid_category_id(cat_id) == [2, 1]
+    assert db.select_budget_id_by_plaid_category_id(cat_id) == 2

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -406,19 +406,35 @@ class FakeStore:
         return result
 
     def select_budget_id_by_plaid_category(self, detailed: str):
+        budget_ids = self.select_budget_ids_by_plaid_category(detailed)
+        return budget_ids[0] if budget_ids else None
+
+    def select_budget_ids_by_plaid_category(self, detailed: str):
         category_id = self.plaid_category_lookup.get(detailed)
         if not category_id:
-            return None
-        for budget_id, mapped_ids in self.plaid_mappings_by_budget.items():
-            if category_id in mapped_ids:
-                return budget_id
-        return None
+            return []
+        return sorted(
+            [
+                budget_id
+                for budget_id, mapped_ids in self.plaid_mappings_by_budget.items()
+                if category_id in mapped_ids
+            ],
+            reverse=True,
+        )
 
     def select_budget_id_by_plaid_category_id(self, plaid_category_id: int):
-        for budget_id, mapped_ids in self.plaid_mappings_by_budget.items():
-            if plaid_category_id in mapped_ids:
-                return budget_id
-        return None
+        budget_ids = self.select_budget_ids_by_plaid_category_id(plaid_category_id)
+        return budget_ids[0] if budget_ids else None
+
+    def select_budget_ids_by_plaid_category_id(self, plaid_category_id: int):
+        return sorted(
+            [
+                budget_id
+                for budget_id, mapped_ids in self.plaid_mappings_by_budget.items()
+                if plaid_category_id in mapped_ids
+            ],
+            reverse=True,
+        )
 
     def insert_plaid_account(self, access_token: str, institution_id: str | None = None):
         self.plaid_inserted_token = access_token
@@ -671,6 +687,34 @@ def test_relink_existing_transactions(service):
     service.sync_all_transactions(month=1, year=2024)
 
     assert (7, 10) in service.store.inserted_budget_transactions
+
+
+def test_relink_prefers_current_month_budget_when_category_is_reused(service):
+    txn = Transaction(
+        id=11,
+        name="Restaurant",
+        amount=2000,
+        direction=TransactionDirection.OUT,
+        occurred_at="2024-03-05",
+        account_id=1,
+        external_id="legacy-2",
+        note="",
+        plaid_category_id=4,
+    )
+    service.store.transactions.append(txn)
+
+    service.store.budgets.extend(
+        [
+            Budget(1, "Food Feb", 500, 0, 0, datetime.datetime(2024, 2, 1)),
+            Budget(2, "Food Mar", 500, 0, 0, datetime.datetime(2024, 3, 1)),
+        ]
+    )
+    service.store.plaid_mappings_by_budget = {1: [4], 2: [4]}
+
+    service.sync_all_transactions(month=3, year=2024)
+
+    assert (2, 11) in service.store.inserted_budget_transactions
+    assert (1, 11) not in service.store.inserted_budget_transactions
 
 
 def test_apple_sync(service):


### PR DESCRIPTION
### Motivation
- Transactions stopped auto-adding to budgets after copying a budget month because the Plaid category lookup returned only a single arbitrary mapping and sync never tried other mapped budgets when the chosen one was out-of-scope.

### Description
- Add multi-result datastore APIs `select_budget_ids_by_plaid_category` and `select_budget_ids_by_plaid_category_id` to the `DataStore` interface and implement them in the SQLite store to return all mapped budget ids ordered newest-first.
- Make existing single-id methods `select_budget_id_by_plaid_category` and `select_budget_id_by_plaid_category_id` delegate to the new multi-id methods for backward compatibility.
- Update `Service` sync and relink flows to iterate candidate mapped budgets and assign the transaction to the first mapped budget that passes month/year scope and direction checks for both detailed and primary category matches.
- Add regression tests covering datastore lookup ordering when a category is mapped in multiple months and service relink behavior preferring the current-month budget when mappings are reused, and update the test fake store to support the new APIs.

### Testing
- Ran targeted tests with `pytest -q -o addopts='' tests/test_db_plaid_categories.py tests/test_service.py` and all tests passed.
- The updated test suite covering the regression cases completed successfully with no failures (28 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5636af57083228b86f9d96b624f59)