### PR TITLE
Support Plaid added/modified/removed transactions and centralize template responses

### DIFF
--- a/apps/web/main.py
+++ b/apps/web/main.py
@@ -101,6 +101,13 @@ app.mount("/static", StaticFiles(directory="apps/web/static"), name="static")
 # MARK: Shared Helpers
 
 
+def _template_response(name: str, context: dict) -> HTMLResponse:
+    request = context.get("request")
+    return templates.TemplateResponse(request, name, context)
+
+# MARK: Shared Helpers
+
+
 def _base_context(service: Service) -> dict:
     return {"summary": service.summary_card}
 
@@ -177,7 +184,7 @@ def _explorer_response(
     year: int | None = None,
     plaid_notice: dict[str, str] | None = None,
 ):
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/explorer/index.html",
         {
             "request": request,
@@ -195,7 +202,7 @@ def _budget_lines_response(
 ) -> HTMLResponse:
     mth_ctx = _month_context(month, year)
     overview = service.get_budget_overview(mth_ctx["current_month"], mth_ctx["year"])
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/budget_lines.html",
         {
             "request": request,
@@ -218,7 +225,7 @@ def read_root(
     month: int | None = Query(None),
     year: int | None = Query(None),
 ) -> HTMLResponse:
-    return templates.TemplateResponse(
+    return _template_response(
         "index.html",
         {"request": request, **_month_context(month, year), **_base_context(service)},
     )
@@ -231,7 +238,7 @@ def dashboard(
     month: int | None = Query(None),
     year: int | None = Query(None),
 ) -> HTMLResponse:
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/dashboard.html",
         {"request": request, **_month_context(month, year), **_base_context(service)},
     )
@@ -241,7 +248,7 @@ def dashboard(
 def summary_card(
     request: Request, service: Annotated[Service, Depends(get_service)]
 ) -> HTMLResponse:
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/summary_card.html", {"request": request, **_base_context(service)}
     )
 
@@ -288,7 +295,7 @@ def explorer_search(
         "query": query,
         **_base_context(service),
     }
-    return templates.TemplateResponse("partials/explorer/search.html", context)
+    return _template_response("partials/explorer/search.html", context)
 
 
 # MARK: - Budget CRUD
@@ -346,7 +353,7 @@ def budget(
 ) -> HTMLResponse:
     service.refresh_budget_spent(id)
     budget = service.get_budget(id)
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/budget/index.html",
         {
             "request": request,
@@ -377,7 +384,7 @@ def budget_update(
 
     budget = service.get_budget(id)
 
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/budget/index.html",
         {
             "request": request,
@@ -417,7 +424,7 @@ def budget_edit(
         value = budget.name
     else:
         value = cents_to_dollars(budget.amount_allocated)
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/budget/edit.html",
         {
             "request": request,
@@ -441,7 +448,7 @@ def budget_transactions(
     year: int | None = Query(None),
 ) -> HTMLResponse:
     budget_spent = service.refresh_budget_spent(id)
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/budget/transactions.html",
         {
             "request": request,
@@ -467,7 +474,7 @@ def create_budget_transaction(
     service.create_budget_transaction(id, name, amount, account_id, date)
     budget_spent = service.refresh_budget_spent(id)
 
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/budget/transactions.html",
         {
             "request": request,
@@ -494,7 +501,7 @@ def update_budget_transaction_note(
     service.update_transaction_note(transaction_id, note)
     budget_spent = service.refresh_budget_spent(id)
 
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/budget/transactions.html",
         {
             "request": request,
@@ -517,7 +524,7 @@ def budget_transaction_delete(
     service.unassign_transaction_to_budget(id, transaction_id)
     budget_spent = service.refresh_budget_spent(id)
 
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/budget/transactions.html",
         {
             "request": request,
@@ -539,7 +546,7 @@ def budget_tags(
     month: int = Query(...),
     year: int | None = Query(None),
 ) -> HTMLResponse:
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/budget/tags.html",
         {
             "request": request,
@@ -561,7 +568,7 @@ def create_budget_tag(
     tag_id = tag_id if tag_id else service.create_tag(name)
     service.assign_tag_to_budget(id, tag_id)
 
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/budget/tags.html",
         {"request": request, "id": id, "tags": service.get_all_budget_tags(id)},
     )
@@ -576,7 +583,7 @@ def budget_tag_delete(
 ) -> HTMLResponse:
     service.unassign_tag_from_budget(id, tag_id)
 
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/budget/tags.html",
         {"request": request, "id": id, "tags": service.get_all_budget_tags(id)},
     )
@@ -590,7 +597,7 @@ def tag_search(
     query: str = Query(None),
 ) -> HTMLResponse:
     tags = service.search_tags(query) if query else []
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/budget/tag/search.html",
         {"request": request, "tags": tags, "id": id, "query": query},
     )
@@ -605,7 +612,7 @@ def budget_plaid_mappings(
     year: int | None = Query(None),
     show_add: bool = Query(False),
 ) -> HTMLResponse:
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/budget/categorization.html",
         {
             "request": request,
@@ -629,7 +636,7 @@ def budget_update_plaid_mappings(
 ) -> HTMLResponse:
     service.set_budget_plaid_category_mappings(id, plaid_categories)
 
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/budget/categorization.html",
         {
             "request": request,
@@ -654,7 +661,7 @@ def context_menu_budgets(
     year: int | None = Query(None),
 ) -> HTMLResponse:
     mth_ctx = _month_context(month, year)
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/explorer/context_menu_budgets.html",
         {
             "request": request,
@@ -822,7 +829,7 @@ def sync_transactions_apple_webhook(
 def link_by_plaid(
     request: Request, service: Annotated[Service, Depends(get_service)]
 ) -> HTMLResponse:
-    return templates.TemplateResponse(
+    return _template_response(
         "partials/plaid_button.html",
         {"request": request, "link_token": service.get_plaid_token()},
     )

--- a/core/datasource/plaid_source.py
+++ b/core/datasource/plaid_source.py
@@ -93,7 +93,7 @@ class Plaid:
 
     def retrieve_transactions(
         self, access_token: str, cursor: str | None = None
-    ) -> tuple[list[Transaction], str | None]:
+    ) -> tuple[list[Transaction], list[Transaction], list[str], str | None]:
         # Plaid rejects a None cursor; omit the field entirely on first sync
         request_kwargs = {"access_token": access_token}
         if cursor:
@@ -101,7 +101,9 @@ class Plaid:
 
         request = TransactionsSyncRequest(**request_kwargs)
         response = self.client.transactions_sync(request)
-        transactions = response["added"]
+        added = list(response["added"])
+        modified = list(response["modified"])
+        removed = [r["transaction_id"] for r in response["removed"]]
         next_cursor = response.get("next_cursor")
 
         while response["has_more"]:
@@ -109,10 +111,12 @@ class Plaid:
                 access_token=access_token, cursor=response["next_cursor"]
             )
             response = self.client.transactions_sync(request)
-            transactions += response["added"]
+            added += response["added"]
+            modified += response["modified"]
+            removed += [r["transaction_id"] for r in response["removed"]]
             next_cursor = response.get("next_cursor", next_cursor)
 
-        return transactions, next_cursor
+        return added, modified, removed, next_cursor
 
     def retrieve_accounts(
         self, access_token: str

--- a/core/datastore/base.py
+++ b/core/datastore/base.py
@@ -49,6 +49,9 @@ class DataStore(ABC):
     def update_transaction_plaid_category(self, id: int, plaid_category_id: int): ...
 
     @abstractmethod
+    def update_transaction(self, id: int, obj: PartialTransaction): ...
+
+    @abstractmethod
     def insert_transaction(self, obj: PartialTransaction) -> int | None: ...
 
     @abstractmethod
@@ -61,6 +64,9 @@ class DataStore(ABC):
     def select_transaction_id_by_fingerprint_or_external_id(
         self, fingerprint: str, external_id: str | None
     ) -> int | None: ...
+
+    @abstractmethod
+    def select_transaction_id_by_external_id(self, external_id: str) -> int | None: ...
 
     @abstractmethod
     def retrieve_transactions(self) -> list[TransactionView]: ...

--- a/core/datastore/db.py
+++ b/core/datastore/db.py
@@ -226,6 +226,21 @@ class Sqlite3(DataStore):
                 .where(self.transactions.c.id == id)
             )
 
+    def update_transaction(self, id: int, obj: PartialTransaction):
+        with self.engine.begin() as conn:
+            values = {
+                "name": obj.name,
+                "amount": dollars_to_cents(obj.amount),
+                "direction": obj.direction,
+                "account_id": obj.account_id,
+                "fingerprint": obj.fingerprint,
+                "external_id": obj.external_id,
+                "occurred_at": obj.occurred_at.isoformat() if obj.occurred_at else None,
+            }
+            conn.execute(
+                update(self.transactions).values(values).where(self.transactions.c.id == id)
+            )
+
     def delete_transaction(self, id: int):
         with self.engine.begin() as conn:
             conn.execute(delete(self.transactions).where(self.transactions.c.id == id))
@@ -249,6 +264,15 @@ class Sqlite3(DataStore):
                 condition = self.transactions.c.fingerprint == fingerprint
             row = conn.execute(
                 select(self.transactions.c.id).where(condition)
+            ).fetchone()
+            return row[0] if row else None
+
+    def select_transaction_id_by_external_id(self, external_id: str) -> int | None:
+        with self.engine.begin() as conn:
+            row = conn.execute(
+                select(self.transactions.c.id).where(
+                    self.transactions.c.external_id == external_id
+                )
             ).fetchone()
             return row[0] if row else None
 

--- a/core/service.py
+++ b/core/service.py
@@ -367,125 +367,166 @@ class Service:
                 if account.plaid_id == plaid_account.id
             }
 
-            transactions, next_cursor = self.plaid_client.retrieve_transactions(
+            added, modified, removed, next_cursor = self.plaid_client.retrieve_transactions(
                 p.token, p.cursor
             )
             self.store.update_plaid_account_cursor(plaid_account.id, next_cursor)
 
             touched_budgets: set[int] = set()
-            for transaction in transactions:
-                account = plaid_item_accounts.get(transaction.account_id)
-                if not account:
-                    continue
-
-                # Depends on enrichment and not guranteed but ideal
-                merchant_name = transaction.merchant_name
-                name = merchant_name if merchant_name else transaction.name
-
-                amount = abs(transaction.amount)
-                date = transaction.date
-                direction = (
-                    TransactionDirection.OUT
-                    if transaction.amount > 0
-                    else TransactionDirection.IN
+            for removed_external_id in removed:
+                existing_id = self.store.select_transaction_id_by_external_id(
+                    removed_external_id
                 )
-                # NOTE
-                # All transactions should be stored as cents
-                fingerprint = Service.__build_transaction_fingerprint(
-                    name, amount, direction, date
-                )
-                transaction_id = self.store.insert_transaction(
-                    PartialTransaction(
-                        name,
-                        amount,
-                        direction,
-                        account.id,
-                        fingerprint,
-                        external_id=transaction.transaction_id,
-                        occurred_at=date,
-                    )
+                if existing_id is not None:
+                    self.store.delete_transaction(existing_id)
+
+            for transaction in added:
+                self.__sync_single_plaid_transaction(
+                    transaction=transaction,
+                    plaid_item_accounts=plaid_item_accounts,
+                    touched_budgets=touched_budgets,
+                    month=month,
+                    year=year,
                 )
 
-                if transaction_id is None:
-                    transaction_id = (
-                        self.store.select_transaction_id_by_fingerprint_or_external_id(
-                            fingerprint, transaction.transaction_id
-                        )
-                    )
-                    if transaction_id is None:
-                        continue
-
-                category = getattr(transaction, "personal_finance_category", None)
-                detailed = getattr(category, "detailed", None) if category else None
-                primary = getattr(category, "primary", None) if category else None
-                category_id = None
-
-                if detailed and primary:
-                    category_id = self.store.upsert_plaid_category(primary, detailed)
-                    # Always persist category on the transaction for future reference
-                    self.store.update_transaction_plaid_category(
-                        transaction_id, category_id
-                    )
-
-
-                assigned_to_mapped_budget = False
-                if detailed:
-                    budget_ids = self.store.select_budget_ids_by_plaid_category(detailed)
-                    for budget_id in budget_ids:
-                        if (
-                            self.__occurs_in_month(date, month, year)
-                            and direction == TransactionDirection.OUT
-                            and self.__budget_in_scope(budget_id, month, year)
-                            and not self.store.ignored_budget_transaction_exists(
-                                budget_id, transaction_id
-                            )
-                        ):
-                            self.store.insert_budget_transaction(
-                                budget_id, transaction_id
-                            )
-                            touched_budgets.add(budget_id)
-                            assigned_to_mapped_budget = True
-                            break
-                    if assigned_to_mapped_budget:
-                        continue
-
-                # Fallback: try primary-level match if detailed not mapped
-                if primary:
-                    budget_ids = self.store.select_budget_ids_by_plaid_category(primary)
-                    for budget_id in budget_ids:
-                        if (
-                            self.__occurs_in_month(date, month, year)
-                            and direction == TransactionDirection.OUT
-                            and self.__budget_in_scope(budget_id, month, year)
-                            and not self.store.ignored_budget_transaction_exists(
-                                budget_id, transaction_id
-                            )
-                        ):
-                            self.store.insert_budget_transaction(
-                                budget_id, transaction_id
-                            )
-                            touched_budgets.add(budget_id)
-                            assigned_to_mapped_budget = True
-                            break
-                    if assigned_to_mapped_budget:
-                        continue
-
-                tag_budget_id = self.__match_budget_by_transaction_tags(
-                    name, date, month, year
+            for transaction in modified:
+                self.__sync_single_plaid_transaction(
+                    transaction=transaction,
+                    plaid_item_accounts=plaid_item_accounts,
+                    touched_budgets=touched_budgets,
+                    month=month,
+                    year=year,
+                    is_modified=True,
                 )
-                if (
-                    tag_budget_id
-                    and self.__occurs_in_month(date, month, year)
-                    and direction == TransactionDirection.OUT
-                    and not self.store.ignored_budget_transaction_exists(
-                        tag_budget_id, transaction_id
-                    )
-                ):
-                    self.store.insert_budget_transaction(tag_budget_id, transaction_id)
-                    touched_budgets.add(tag_budget_id)
 
             for budget_id in touched_budgets:
                 self.refresh_budget_spent(budget_id)
+
+    def __sync_single_plaid_transaction(
+        self,
+        transaction,
+        plaid_item_accounts: dict,
+        touched_budgets: set[int],
+        month: int | None = None,
+        year: int | None = None,
+        is_modified: bool = False,
+    ):
+        account = plaid_item_accounts.get(transaction.account_id)
+        if not account:
+            return
+
+        # Depends on enrichment and not guranteed but ideal
+        merchant_name = transaction.merchant_name
+        name = merchant_name if merchant_name else transaction.name
+
+        amount = abs(transaction.amount)
+        date = transaction.date
+        direction = (
+            TransactionDirection.OUT
+            if transaction.amount > 0
+            else TransactionDirection.IN
+        )
+        # NOTE
+        # All transactions should be stored as cents
+        fingerprint = Service.__build_transaction_fingerprint(
+            name, amount, direction, date
+        )
+
+        existing_id = self.store.select_transaction_id_by_external_id(
+            transaction.transaction_id
+        )
+        if is_modified and existing_id is not None:
+            self.store.update_transaction(
+                existing_id,
+                PartialTransaction(
+                    name,
+                    amount,
+                    direction,
+                    account.id,
+                    fingerprint,
+                    external_id=transaction.transaction_id,
+                    occurred_at=date,
+                ),
+            )
+            transaction_id = existing_id
+        else:
+            transaction_id = self.store.insert_transaction(
+                PartialTransaction(
+                    name,
+                    amount,
+                    direction,
+                    account.id,
+                    fingerprint,
+                    external_id=transaction.transaction_id,
+                    occurred_at=date,
+                )
+            )
+
+            if transaction_id is None:
+                transaction_id = self.store.select_transaction_id_by_fingerprint_or_external_id(
+                    fingerprint, transaction.transaction_id
+                )
+                if transaction_id is None:
+                    return
+
+        category = getattr(transaction, "personal_finance_category", None)
+        detailed = getattr(category, "detailed", None) if category else None
+        primary = getattr(category, "primary", None) if category else None
+
+        if detailed and primary:
+            category_id = self.store.upsert_plaid_category(primary, detailed)
+            # Always persist category on the transaction for future reference
+            self.store.update_transaction_plaid_category(transaction_id, category_id)
+
+        assigned_to_mapped_budget = False
+        if detailed:
+            budget_ids = self.store.select_budget_ids_by_plaid_category(detailed)
+            for budget_id in budget_ids:
+                if (
+                    self.__occurs_in_month(date, month, year)
+                    and direction == TransactionDirection.OUT
+                    and self.__budget_in_scope(budget_id, month, year)
+                    and not self.store.ignored_budget_transaction_exists(
+                        budget_id, transaction_id
+                    )
+                ):
+                    self.store.insert_budget_transaction(budget_id, transaction_id)
+                    touched_budgets.add(budget_id)
+                    assigned_to_mapped_budget = True
+                    break
+            if assigned_to_mapped_budget:
+                return
+
+        # Fallback: try primary-level match if detailed not mapped
+        if primary:
+            budget_ids = self.store.select_budget_ids_by_plaid_category(primary)
+            for budget_id in budget_ids:
+                if (
+                    self.__occurs_in_month(date, month, year)
+                    and direction == TransactionDirection.OUT
+                    and self.__budget_in_scope(budget_id, month, year)
+                    and not self.store.ignored_budget_transaction_exists(
+                        budget_id, transaction_id
+                    )
+                ):
+                    self.store.insert_budget_transaction(budget_id, transaction_id)
+                    touched_budgets.add(budget_id)
+                    assigned_to_mapped_budget = True
+                    break
+            if assigned_to_mapped_budget:
+                return
+
+        tag_budget_id = self.__match_budget_by_transaction_tags(name, date, month, year)
+        if (
+            tag_budget_id
+            and self.__occurs_in_month(date, month, year)
+            and direction == TransactionDirection.OUT
+            and not self.store.ignored_budget_transaction_exists(
+                tag_budget_id, transaction_id
+            )
+        ):
+            self.store.insert_budget_transaction(tag_budget_id, transaction_id)
+            touched_budgets.add(tag_budget_id)
 
     def __relink_transactions_to_mapped_budgets(
         self, month: int | None = None, year: int | None = None

--- a/tests/datasource/test_plaid_source.py
+++ b/tests/datasource/test_plaid_source.py
@@ -96,8 +96,20 @@ class DummyPlaidApi:
         self.accounts_requests = []
         self.remove_requests = []
         self.transactions_responses = [
-            {"added": ["t1"], "has_more": True, "next_cursor": "cursor-1"},
-            {"added": ["t2"], "has_more": False, "next_cursor": "cursor-2"},
+            {
+                "added": ["t1"],
+                "modified": ["m1"],
+                "removed": [{"transaction_id": "r1"}],
+                "has_more": True,
+                "next_cursor": "cursor-1",
+            },
+            {
+                "added": ["t2"],
+                "modified": ["m2"],
+                "removed": [{"transaction_id": "r2"}],
+                "has_more": False,
+                "next_cursor": "cursor-2",
+            },
         ]
 
     def link_token_create(self, request):
@@ -258,9 +270,11 @@ def test_add_financial_item_exchanges_token():
 def test_retrieve_transactions_pages_and_aggregates():
     plaid = plaid_source.Plaid()
 
-    transactions, next_cursor = plaid.retrieve_transactions("access-123")
+    added, modified, removed, next_cursor = plaid.retrieve_transactions("access-123")
 
-    assert transactions == ["t1", "t2"]
+    assert added == ["t1", "t2"]
+    assert modified == ["m1", "m2"]
+    assert removed == ["r1", "r2"]
     assert next_cursor == "cursor-2"
     first_request, second_request = plaid.client.sync_requests
     assert first_request.access_token == "access-123"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -111,7 +111,7 @@ class FakePlaid:
                     "plaid-credit-acc",
                     Category("FOOD_AND_DRINK", "FOOD_AND_DRINK_COFFEE"),
                 ),
-            ], "cursor-1-new"
+            ], [], [], "cursor-1-new"
 
         return [
             Txn(
@@ -132,7 +132,7 @@ class FakePlaid:
                 "plaid-checking-acc",
                 Category("INCOME", "INCOME_WAGES"),
             ),
-        ], "cursor-2-new"
+        ], [], [], "cursor-2-new"
 
 
 class FakeStore:
@@ -186,6 +186,7 @@ class FakeStore:
         self.updated_account_balances = []
         self.updated_account_display_names = []
         self.ignored_budget_transactions = set()
+        self.updated_transactions = []
 
     def insert_budget(self, name, allocated, created_at=None):
         self.inserted_budgets.append((name, allocated, created_at))
@@ -271,6 +272,9 @@ class FakeStore:
             return self.transaction_external_ids[external_id]
         return self.transaction_fingerprints.get(fingerprint)
 
+    def select_transaction_id_by_external_id(self, external_id: str):
+        return self.transaction_external_ids.get(external_id)
+
     def insert_budget_transaction(self, budget_id: int, transaction_id: int):
         self.inserted_budget_transactions.append((budget_id, transaction_id))
 
@@ -296,11 +300,46 @@ class FakeStore:
         self.plaid_category_updates.append((id, plaid_category_id))
         self.transaction_plaid_category_ids[id] = plaid_category_id
 
+    def update_transaction(self, id: int, partial: PartialTransaction):
+        existing = self.transactions[id]
+        updated = Transaction(
+            id=id,
+            name=partial.name,
+            amount=partial.amount,
+            direction=partial.direction,
+            occurred_at=partial.occurred_at,
+            account_id=partial.account_id,
+            external_id=partial.external_id,
+            note=getattr(existing, "note", None),
+            plaid_category_id=self.transaction_plaid_category_ids.get(id),
+        )
+        self.transactions[id] = updated
+        self.transaction_fingerprints[partial.fingerprint] = id
+        if partial.external_id:
+            self.transaction_external_ids[partial.external_id] = id
+        self.updated_transactions.append(id)
+
     def select_budget_id_for_transaction(self, transaction_id: int):
         return self.selected_budget_id
 
     def delete_budget_transaction(self, budget_id: int, transaction_id: int):
         self.deleted_budget_transactions.append((budget_id, transaction_id))
+
+    def delete_transaction(self, id: int):
+        transaction = self.transactions[id]
+        external_id = getattr(transaction, "external_id", None)
+        if external_id:
+            self.transaction_external_ids.pop(external_id, None)
+        self.transactions[id] = Transaction(
+            id=id,
+            name="__deleted__",
+            amount=0,
+            direction=TransactionDirection.OUT,
+            occurred_at="1970-01-01",
+            account_id=1,
+            external_id=None,
+            note=None,
+        )
 
     def retrieve_plaid_accounts(self):
         return self.plaid_accounts
@@ -630,6 +669,56 @@ def test_plaid_sync_respects_month_scope(service):
     assert service.store.inserted_budget_transactions == []
 
 
+def test_plaid_sync_applies_removed_and_modified(service):
+    # Seed an existing pending transaction that should be removed on sync.
+    seeded = PartialTransaction(
+        name="Pending Card Auth",
+        amount=40,
+        direction=TransactionDirection.OUT,
+        account_id=1,
+        fingerprint="fp-pending",
+        external_id="pending-1",
+        occurred_at=datetime.datetime(2023, 1, 10),
+    )
+    service.store.insert_transaction(seeded)
+
+    class Txn:
+        def __init__(self, amount: float):
+            self.account_id = "plaid-credit-acc"
+            self.amount = amount
+            self.date = datetime.datetime(2023, 1, 10)
+            self.transaction_id = "posted-1"
+            self.merchant_name = "Coffee Shop"
+            self.name = "Coffee Shop"
+            self.personal_finance_category = type(
+                "Cat",
+                (),
+                {
+                    "primary": "FOOD_AND_DRINK",
+                    "detailed": "FOOD_AND_DRINK_COFFEE",
+                },
+            )
+
+    # Added + modified for the same posted transaction should not create duplicates.
+    service.plaid_client.retrieve_transactions = lambda access_token, cursor=None: (
+        [Txn(30.00)],
+        [Txn(32.50)],
+        ["pending-1"],
+        "cursor-new",
+    )
+
+    service.sync_all_transactions(month=1, year=2023)
+
+    assert service.store.select_transaction_id_by_external_id("pending-1") is None
+    posted_ids = [
+        idx
+        for idx, txn in enumerate(service.store.transactions)
+        if getattr(txn, "external_id", None) == "posted-1"
+    ]
+    assert len(posted_ids) == 1
+    assert posted_ids[0] in service.store.updated_transactions
+
+
 def test_sync_links_only_outgoing(service):
     # Make one incoming transaction category mapped; should not be linked
     class Txn:
@@ -649,6 +738,8 @@ def test_sync_links_only_outgoing(service):
     # Override retrieve_transactions to return a crafted IN transaction
     service.plaid_client.retrieve_transactions = lambda access_token, cursor=None: (
         [Txn(TransactionDirection.IN)],
+        [],
+        [],
         "c-new",
     )
 


### PR DESCRIPTION
### Motivation
- Consolidate HTML template rendering to a single helper to reduce repetition and potential mistakes when returning templates. 
- Properly handle Plaid sync deltas so added, modified, and removed transactions are processed without creating duplicates and the database stays consistent. 

### Description
- Add `_template_response(name: str, context: dict)` and replace direct `templates.TemplateResponse(...)` calls across `apps/web/main.py` with the helper. 
- Change `Plaid.retrieve_transactions` to return `(added, modified, removed, next_cursor)` and aggregate `modified`/`removed` entries while paging in `core/datasource/plaid_source.py`. 
- Add `update_transaction` and `select_transaction_id_by_external_id` to the `DataStore` abstraction in `core/datastore/base.py` and implement them in the SQLite store (`core/datastore/db.py`) along with an `update_transaction` implementation that updates fields from a `PartialTransaction`. 
- Rework Plaid sync logic in `core/service.py` to: delete transactions listed in `removed`, update existing transactions when `modified`, and insert `added` transactions; extract per-transaction processing into `__sync_single_plaid_transaction` and keep budget mapping and touched-budget refresh behavior intact. 
- Update tests to match the new retrieve signature and sync behavior, and add `test_plaid_sync_applies_removed_and_modified` to assert removal and modification handling in `tests/test_service.py` and adjust `tests/datasource/test_plaid_source.py` accordingly. 

### Testing
- Ran unit tests for the Plaid datasource and service (including `tests/datasource/test_plaid_source.py` and `tests/test_service.py`) under the updated test suite. 
- All updated and new tests passed locally, including the new `test_plaid_sync_applies_removed_and_modified` which verifies removal and modification handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9af45eed88322bda8890d3b6a785e)